### PR TITLE
Channel find scale

### DIFF
--- a/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
+++ b/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
@@ -771,6 +771,22 @@ class Lecroy_WR8xxx(Scpi_Instrument):
                  f""""{position}" '""")
         self.instrument.write(q_str)
 
+    def set_channel_label_view(self, channel: int, view: str = 'ON') -> None:
+        """
+        set_channel_label_view(channel, position)
+
+        updates the text label position on a channel specified by "channel"
+        with the position given in "position".
+
+        Args:
+            channel (int): channel number to update label of.
+            view (str): ON or OFF to view label
+        """
+
+        q_str = (f"""vbs 'app.acquisition.C{channel}.LabelsPosition = """ +
+                 f""""{view}" '""")
+        self.instrument.write(q_str)
+
     def set_channel_display(self, channel, mode):
         # mode = "true" or "false"
         q_str = f"""vbs 'app.acquisition.C{channel}.View = {mode} '"""

--- a/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
+++ b/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
@@ -782,6 +782,10 @@ class Lecroy_WR8xxx(Scpi_Instrument):
     def set_channel_label_view(self, channel: int, view: bool = True) -> None:
         """set_channel_label_view(channel, view)
 
+        Turn channel label visibility on or off, also resets label position to
+        trigger position (time zero).  Use set_channel_label_position() AFTER
+        this command to prevent loss of position setting.
+
         Args:
             channel (int): channel number to show/hide the label of
             view (bool, optional): True = label 'ON', False = label 'OFF'
@@ -797,7 +801,7 @@ class Lecroy_WR8xxx(Scpi_Instrument):
         set_channel_findscale(channel)
 
         updates the scale on a channel specified by "channel"
-        automatically to fit singal on screen.
+        automatically to fit signal on screen.
 
         Args:
             channel (int): channel number to update scale of.

--- a/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
+++ b/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
@@ -755,6 +755,22 @@ class Lecroy_WR8xxx(Scpi_Instrument):
 
         return ' '.join(response.strip().split()[1:])
 
+    def set_channel_label_position(self, channel: int, position=0) -> None:
+        """
+        set_channel_label_position(channel, position)
+
+        updates the text label position on a channel specified by "channel"
+        with the position given in "position".
+
+        Args:
+            channel (int): channel number to update label of.
+            position (int): position trigger relative to place label
+        """
+
+        q_str = (f"""vbs 'app.acquisition.C{channel}.LabelsPosition = """ +
+                 f""""{position}" '""")
+        self.instrument.write(q_str)
+
     def set_channel_display(self, channel, mode):
         # mode = "true" or "false"
         q_str = f"""vbs 'app.acquisition.C{channel}.View = {mode} '"""

--- a/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
+++ b/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
@@ -480,15 +480,10 @@ class Lecroy_WR8xxx(Scpi_Instrument):
 
     def set_trigger_level_auto(self) -> None:
         """
-        set_trigger_level_auto(**kwargs)
+        set_trigger_level_auto()
 
         Sets the vertical position of the trigger point.
         Automatically sets trigger level to signal mean.
-
-        Args:
-            None
-        Kwargs:
-            None
         """
 
         self.instrument.write(f"""vbs 'app.acquisition.Trigger.FindLevel'""")

--- a/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
+++ b/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
@@ -478,6 +478,21 @@ class Lecroy_WR8xxx(Scpi_Instrument):
 
         return float(response.lstrip(read_cmd).split()[0])
 
+    def set_trigger_level_auto(self) -> None:
+        """
+        set_trigger_level_auto(**kwargs)
+
+        Sets the vertical position of the trigger point.
+        Automatically sets trigger level to signal mean.
+
+        Args:
+            None
+        Kwargs:
+            None
+        """
+
+        self.instrument.write(f"""vbs 'app.acquisition.Trigger.FindLevel'""")
+
     def set_trigger_slope(self, slope: str, **kwargs) -> None:
         """
         set_trigger_slope(slope, **kwargs)
@@ -785,6 +800,20 @@ class Lecroy_WR8xxx(Scpi_Instrument):
 
         q_str = (f"""vbs 'app.acquisition.C{channel}.LabelsPosition = """ +
                  f""""{view}" '""")
+        self.instrument.write(q_str)
+
+    def set_channel_findscale(self, channel: int) -> None:
+        """
+        set_channel_findscale(channel)
+
+        updates the scale on a channel specified by "channel"
+        automatically to fit singal on screen.
+
+        Args:
+            channel (int): channel number to update scale of.
+        """
+
+        q_str = (f"""vbs 'app.acquisition.C{channel}.FindScale'""")
         self.instrument.write(q_str)
 
     def set_channel_display(self, channel, mode):

--- a/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
+++ b/pythonequipmentdrivers/oscilloscope/Lecroy_WR8xxx.py
@@ -765,36 +765,31 @@ class Lecroy_WR8xxx(Scpi_Instrument):
 
         return ' '.join(response.strip().split()[1:])
 
-    def set_channel_label_position(self, channel: int, position=0) -> None:
-        """
-        set_channel_label_position(channel, position)
-
-        updates the text label position on a channel specified by "channel"
-        with the position given in "position".
+    def set_channel_label_position(self, channel: int,
+                                   position: float = 0) -> None:
+        """set_channel_label_position(channel, position)
 
         Args:
-            channel (int): channel number to update label of.
-            position (int): position trigger relative to place label
+            channel (int): channel number to update the label of
+            position (float, optional): time position relative to trigger to
+            place the label. Units are in seconds. Defaults to 0.
         """
 
         q_str = (f"""vbs 'app.acquisition.C{channel}.LabelsPosition = """ +
                  f""""{position}" '""")
         self.instrument.write(q_str)
 
-    def set_channel_label_view(self, channel: int, view: str = 'ON') -> None:
-        """
-        set_channel_label_view(channel, position)
-
-        updates the text label position on a channel specified by "channel"
-        with the position given in "position".
+    def set_channel_label_view(self, channel: int, view: bool = True) -> None:
+        """set_channel_label_view(channel, view)
 
         Args:
-            channel (int): channel number to update label of.
-            view (str): ON or OFF to view label
+            channel (int): channel number to show/hide the label of
+            view (bool, optional): True = label 'ON', False = label 'OFF'
+            Defaults to True 'ON'
         """
 
         q_str = (f"""vbs 'app.acquisition.C{channel}.LabelsPosition = """ +
-                 f""""{view}" '""")
+                 f""""{'ON' if view else 'OFF'}" '""")
         self.instrument.write(q_str)
 
     def set_channel_findscale(self, channel: int) -> None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='pythonequipmentdrivers',
-      version='1.11.0',
+      version='1.10.1',
       description="""
                   A library of software drivers to interface with various
                   pieces of test instrumentation

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='pythonequipmentdrivers',
-      version='1.10.0',
+      version='1.11.0',
       description="""
                   A library of software drivers to interface with various
                   pieces of test instrumentation


### PR DESCRIPTION
add set trigger level automatically
puts the trigger level onto signal mean (uses the mean it can see right now, so if a new signal will arrive later, this isn't as helpful)
add channel find level.
Sets the currently visible channel data to be within +/- 3 divisions of centered.  It takes the scope some time to do this so don't rush it.
