### PR TITLE
Add class for Koolance EXC900 

### DIFF
--- a/pythonequipmentdrivers/__init__.py
+++ b/pythonequipmentdrivers/__init__.py
@@ -16,6 +16,7 @@ from . import oscilloscope
 from . import networkanalyzer
 
 from . import functiongenerator
+from . import temperaturecontroller
 
 
 __all__ = ['Scpi_Instrument', 'get_devices_addresses', 'identify_devices',
@@ -35,4 +36,5 @@ __all__ = ['Scpi_Instrument', 'get_devices_addresses', 'identify_devices',
            'networkanalyzer',
 
            'functiongenerator',
+           'temperaturecontroller'
            ]

--- a/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
+++ b/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
@@ -74,7 +74,7 @@ class Koolance_EXC900(Scpi_Instrument):
         data = self._read_data()
         out_dict = {}
         for name, (offs, n_bytes, m, r, b) in self.DATA_REGISTER_MAP.items():
-            selected = data[offs : offs + n_bytes]
+            selected = data[offs: offs + n_bytes]
             val = int.from_bytes(selected, "big")
             val = (1 / m) * (val * 10 ** (-1 * r) - b)
             out_dict[name] = val
@@ -101,7 +101,7 @@ class Koolance_EXC900(Scpi_Instrument):
                 raise TypeError(f"{name} is not a valid setting name")
             value = round((m * value + b) * 10**r)
             val_bytes = value.to_bytes(n_bytes, "big")
-            data[offs : offs + n_bytes] = val_bytes
+            data[offs: offs + n_bytes] = val_bytes
 
         data[0:2] = [0xCF, 0x04]  # configure the command bytes for a write
         data[2:14] = 12 * [0]  # set read-only locations to 0
@@ -137,7 +137,8 @@ class Koolance_EXC900(Scpi_Instrument):
             Temperature sensor configuration to use. Defaults to "liq".
         """
         if sensor_config not in {"liq", "ext", "liq_amb", "ext_amb"}:
-            raise ValueError(f"sensor_config={sensor_config} is not a valid option")
+            raise ValueError(
+                f"sensor_config={sensor_config} is not a valid option")
         self.update_settings(**{f"usr_temp_sp_{sensor_config}": temp})
 
     def measure_temperature(

--- a/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
+++ b/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
@@ -1,0 +1,58 @@
+from pythonequipmentdrivers import Scpi_Instrument
+import numpy as np
+from time import sleep
+from typing import Union, Tuple
+
+
+class Koolance_EXC900(Scpi_Instrument):
+    DATA_REGISTER_MAP = {
+        # kwarg, offset, width, m, r, b
+        # TODO: implement more of the map
+        # monitoring data
+        "mon_liq_temp": (2, 2, 10, 0, 2000),
+        "mon_ext_temp": (4, 2, 10, 0, 2000),
+        "mon_amb_temp": (6, 2, 10, 0, 2000),
+        "mon_fan_rpm": (8, 2, 1, 0, 0),
+        "mon_pump_rpm": (10, 2, 1, 0, 0),
+        "mon_flow_meter": (12, 2, 1, 1, 0),
+        # user mode settings
+        "usr_temp_sp": (14, 2, 1, 0, 500),
+        "usr_pump_sp": (16, 2, 1, 0, 0),
+        "usr_flow_sp": (18, 2, 1, 0, 0),
+        # units
+        "units": (44, 2, 1, 0, 0),
+    }
+
+    def __init__(self, address, **kwargs):
+        super().__init__(address, **kwargs)
+
+    def _read_data(self) -> bytes:
+        data_request_command = [0xCF, 0x01, 0x08]
+        self.instrument.write_raw(bytes(data_request_command))
+        return self.instrument.read_bytes(51)
+
+    def _write_data(self, data: bytes) -> None:
+        self.instrument.write_raw(data)
+
+    def get_settings(self) -> dict:
+        data = self._read_data()
+        out_dict = {}
+        for name, (offs, n_bytes, m, r, b) in self.DATA_REGISTER_MAP.items():
+            selected = data[offs : offs + n_bytes]
+            val = int.from_bytes(selected, "big")
+            val = (1 / m) * (val * 10 ** (-1 * r) - b)
+            out_dict[name] = val
+        return out_dict
+
+    def set_settings(self, **kwargs) -> dict:
+        data = bytearray(self._read_data())
+        for name, value in kwargs.items():
+            offs, n_bytes, m, r, b = self.DATA_REGISTER_MAP[name]
+            value = round((m * value + b) * 10 ** r)
+            val_bytes = value.to_bytes(n_bytes, "big")
+            data[offs : offs + n_bytes] = val_bytes
+
+        data[0:2] = [0xCF, 0x04]
+        data[2:14] = 12 * [0]
+        data[50] = sum(data[:50]) % 0x64
+        self._write_data(bytes(data))

--- a/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
+++ b/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
@@ -73,7 +73,7 @@ class Koolance_EXC900(Scpi_Instrument):
                 offs, n_bytes, m, r, b = self.DATA_REGISTER_MAP[name]
             except KeyError:
                 raise TypeError(f"{name} is not a valid setting name")
-            value = round((m * value + b) * 10**r)
+            value = round((m * value + b) * 10 ** r)
             val_bytes = value.to_bytes(n_bytes, "big")
             data[offs : offs + n_bytes] = val_bytes
 
@@ -96,7 +96,7 @@ class Koolance_EXC900(Scpi_Instrument):
     ) -> None:
         if sensor_config not in {"liq", "ext", "liq_amb", "ext_amb"}:
             raise ValueError(f"sensor_config={sensor_config} is not a valid option")
-        self.update_settings({f"usr_temp_sp_{sensor_config}": temp})
+        self.update_settings(**{f"usr_temp_sp_{sensor_config}": temp})
 
     def measure_temperature(self, sensor: Literal["liq", "ext", "amb"] = "liq"):
         try:

--- a/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
+++ b/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
@@ -1,4 +1,3 @@
-from argparse import ArgumentError
 from pythonequipmentdrivers import Scpi_Instrument
 import numpy as np
 from time import sleep

--- a/pythonequipmentdrivers/temperaturecontroller/__init__.py
+++ b/pythonequipmentdrivers/temperaturecontroller/__init__.py
@@ -1,5 +1,4 @@
 from .Koolance_EXC900 import Koolance_EXC900
 
 
-
-__all__ = ['Koolance_EXC900',]
+__all__ = ['Koolance_EXC900', ]

--- a/pythonequipmentdrivers/temperaturecontroller/__init__.py
+++ b/pythonequipmentdrivers/temperaturecontroller/__init__.py
@@ -1,0 +1,5 @@
+from .Koolance_EXC900 import Koolance_EXC900
+
+
+
+__all__ = ['Koolance_EXC900',]


### PR DESCRIPTION
I have created a class to support controlling a Koolance EXC900 and new folder for it (`temperaturecontroller.Koolance_EXC900`). Implemented is most of the commonly used functionality such as:
* Setting and getting the temperature setpoints - `get_temperature()`, `set_temperature()`
* Reading the measured temperature of the various available sensors - `measure_temperature()`
* Setting and getting the measurement units - `set_units()`, `get_units()`

Due to the relatively slow read and writes I added a buffering functionality to the low level read method (`_read_data()`) that will only fetch new data if the currently held data is older than a time limit (1s default) or when a write has occurred. 

`DATA_REGISTER_MAP` encapsulates all information necessary for accessing parameters in the byte array. This could be expanded in the future to add any missing functionality. 