### PR TITLE
Added AttrDict class

### DIFF
--- a/pythonequipmentdrivers/utility/__init__.py
+++ b/pythonequipmentdrivers/utility/__init__.py
@@ -1,5 +1,6 @@
 from .data_management import (log_data, dump_data, create_test_log,
                               dump_array_data)
+from .data_structures import AttrDict
 
-
-__all__ = ['log_data', 'dump_data', 'create_test_log', 'dump_array_data']
+__all__ = ['log_data', 'dump_data',
+           'create_test_log', 'dump_array_data', 'AttrDict']

--- a/pythonequipmentdrivers/utility/data_structures.py
+++ b/pythonequipmentdrivers/utility/data_structures.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+
+class AttrDict(dict):
+    """
+    An extension of Dict that allows access to its values via attributes where
+    the key is the attribute name. In order to accomplish this keys can only
+    be of the str type.
+    """
+
+    def __init__(self, **kwargs):
+        for key in kwargs:
+            if not isinstance(key, str):
+                raise TypeError("keywords must be strings")
+        super().__init__(self, **kwargs)
+
+    def __setitem__(self, __k: str, v: Any) -> None:
+        if not isinstance(__k, str):
+            raise TypeError("keywords must be strings")
+        return super().__setitem__(__k, v)
+
+    def __setattr__(self, __name: str, __value: Any) -> None:
+        #self[__name] = __value
+        self.__setitem__(__name, __value)
+
+    def __getattr__(self, __name: str) -> None:
+        # return self[__name]
+        return self.__getitem__(__name)
+
+    def __repr__(self) -> str:
+        s = f"{self.__class__.__name__}("
+        s += ", ".join(f"{k}={v}" for k, v in self.items())
+        s += ")"
+        return s


### PR DESCRIPTION
Created an extension of dict that allows access to its values via attributes where the key is the attribute name. In order to accomplish this keys can only be of the str type.

This is primarily used for recording data during sweeps i.e. a datum. The ability to access values with attributes improves readability compared to using a standard dict.

```python
# from this
datum['eff'] = datum['pout'] * datum['pin']
# to this
datum.eff = datum.pout * datum.pin
```

