### PR TITLE
Added class for the Fluke_8845A

### DIFF
--- a/pythonequipmentdrivers/multimeter/Fluke_8845A.py
+++ b/pythonequipmentdrivers/multimeter/Fluke_8845A.py
@@ -1,0 +1,29 @@
+from .HP_34401A import HP_34401A
+
+
+class Fluke_8845A(HP_34401A):
+    """
+    Fluke_8845A(address, factor=1)
+
+    address: str, address of the connected multimeter
+
+    factor: float, multiplicitive scale for all measurements defaults to 1.
+
+    object for accessing basic functionallity of the FLUKE_8845A multimeter.
+    The factor term allows for measurements to be multiplied by some number
+    before being returned. For example, in the case of measuring the voltage
+    across a current shunt this factor can represent the conductance of the
+    shunt. This factor defaults to 1 (no effect on measurement).
+    """
+
+    def __init__(self, address, **kwargs):
+        super().__init__(address, **kwargs)
+
+    def disable_cmd_emulation_mode(self):
+        """
+        disable_cmd_emulation_mode()
+
+        Disable the Fluke 45 command set emulation mode i.e. use Fluke8845
+        native commands.
+        """
+        self.instrument.write("L1")

--- a/pythonequipmentdrivers/multimeter/__init__.py
+++ b/pythonequipmentdrivers/multimeter/__init__.py
@@ -2,11 +2,12 @@ from .Fluke_45 import Fluke_45
 from .Fluke_DMM import Fluke_DMM
 from .HP_34401A import HP_34401A
 from .Keysight_34461A import Keysight_34461A
-
+from .Fluke_8845A import Fluke_8845A
 
 __all__ = [
-           'Fluke_45',
-           'Fluke_DMM',
-           'HP_34401A',
-           'Keysight_34461A',
-           ]
+    'Fluke_45',
+    'Fluke_DMM',
+    'HP_34401A',
+    'Keysight_34461A',
+    'Fluke_8845A'
+]


### PR DESCRIPTION
The Fluke8845A shares the same command set as HP_34401A except for a
Fluke 45 emulation mode command