### PR TITLE
Keithley2231 Updates

### DIFF
--- a/pythonequipmentdrivers/source/Keithley_2231A.py
+++ b/pythonequipmentdrivers/source/Keithley_2231A.py
@@ -3,9 +3,15 @@ from pythonequipmentdrivers import VisaResource
 
 class Keithley_2231A(VisaResource):
     """
-    Keithley_2231A(address)
+    Keithley_2231A(address, channel)
 
     address : str, address of the connected power supply
+    channel : int, if not None this instance will be associated
+        with a particular output channel. The channel argument will no longer
+        need to be supplied for any subsequent method call. However, supplying
+        the channel argument will override the channel that is associated
+        with the instance.
+
 
     object for accessing basic functionallity of the Keithley DC supply
     """


### PR DESCRIPTION
Update allows constructor to receive a channel argument, method calls will then automatically utilize this assigned channel number without need to provide a channel number with each call. By default a channel of None is assigned and there is no functional difference from the prior revision. 

In essence this allows each channel of the BK9129B or similar to behave like a separate supply. 