### PR TITLE
Various Updates to Address Open Issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pythonequipmentdrivers"
-version = "2.4.0"
+version = "2.5.0"
 authors = [
   { name="Anna Giasson", email="AnnaGraceGiasson@GMail.com" },
 ]

--- a/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
+++ b/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
@@ -268,6 +268,11 @@ class HP_34401A(VisaResource):
         response = self.query_resource("TRIG:COUN?", **kwargs)
         return int(self.resp_format(response, float))
 
+    def _measure_with_current_range(self, measurement_str: str):
+
+        current_range = self.query_resource(f"SENS:{measurement_str}:RANG?")
+        return self.query_resource(f"MEAS:{measurement_str}? {current_range}")
+
     def measure_voltage(self):
         """
         measure_voltage()
@@ -282,7 +287,7 @@ class HP_34401A(VisaResource):
         """
         if self.get_mode() != "VOLT":
             raise IOError("Multimeter is not configured to measure voltage")
-        response = self.query_resource("MEAS:VOLT:DC?")
+        response = self._measure_with_current_range("VOLT:DC")
         return self.factor * float(response)
 
     def measure_voltage_rms(self):
@@ -299,7 +304,7 @@ class HP_34401A(VisaResource):
         """
         if self.get_mode() != "VOLT:AC":
             raise IOError("Multimeter is not configured to measure AC voltage")
-        response = self.query_resource("MEAS:VOLT:AC?")
+        response = self._measure_with_current_range("VOLT:AC")
         return self.factor * float(response)
 
     def measure_current(self):
@@ -316,7 +321,7 @@ class HP_34401A(VisaResource):
         """
         if self.get_mode() != "CURR":
             raise IOError("Multimeter is not configured to measure current")
-        response = self.query_resource("MEAS:CURR:DC?")
+        response = self._measure_with_current_range("CURR:DC")
         return self.factor * float(response)
 
     def measure_current_rms(self):
@@ -333,7 +338,7 @@ class HP_34401A(VisaResource):
         """
         if self.get_mode() != "CURR:AC":
             raise IOError("Multimeter is not configured to measure AC current")
-        response = self.query_resource("MEAS:CURR:AC?")
+        response = self._measure_with_current_range("CURR:AC")
         return self.factor * float(response)
 
     def measure_resistance(self):
@@ -350,7 +355,7 @@ class HP_34401A(VisaResource):
         """
         if self.get_mode() != "RES":
             raise IOError("Multimeter is not configured to measure resistance")
-        response = self.query_resource("MEAS:RES?")
+        response = self._measure_with_current_range("RES")
         return float(response)
 
     def measure_frequency(self):
@@ -367,7 +372,7 @@ class HP_34401A(VisaResource):
         """
         if self.get_mode() != "FREQ":
             raise IOError("Multimeter is not configured to measure frequency")
-        response = self.query_resource("MEAS:FREQ?")
+        response = self._measure_with_current_range("FREQ")
         return float(response)
 
     def init(self, **kwargs) -> None:

--- a/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
+++ b/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
@@ -471,7 +471,7 @@ class HP_34401A(VisaResource):
         acdc = valid_acdc[acdc] if not usefreq else ""
 
         # if range is not provided, cannot use nplc in CONF command
-        signal_range = signal_range.upper()
+        signal_range = str(signal_range).upper()
         if signal_range == "AUTO":
             signal_range = False
 
@@ -553,4 +553,7 @@ class HP_34401A(VisaResource):
         return self.measure_time
 
     def set_local(self, **kwargs) -> None:
-        self.write_resource("SYSTem:LOCal", **kwargs)
+        if "GPIB" not in self.address:
+            self.write_resource("SYSTem:LOCal", **kwargs)
+        else:
+            super().set_local()

--- a/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
+++ b/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
@@ -268,12 +268,25 @@ class HP_34401A(VisaResource):
         response = self.query_resource("TRIG:COUN?", **kwargs)
         return int(self.resp_format(response, float))
 
-    def _measure_with_current_range(self, measurement_str: str):
+    def _measure_with_current_range(self, measurement_str: str) -> str:
+        """
+        Perform a measurement using the provided measurement str. Maintain the current
+        range or auto mode if set
+
+        Args:
+            measurement_str (str): Base command for measurement e.g. "VOLT:DC"
+
+        Returns:
+            str: measurement returned as string
+        """
 
         current_range = self.query_resource(f"SENS:{measurement_str}:RANG?")
-        return self.query_resource(f"MEAS:{measurement_str}? {current_range}")
+        autorange = int(self.query_resource(f"SENS:{measurement_str}:RANG:AUTO?")) == 1
+        return self.query_resource(
+            f"MEAS:{measurement_str}?{' '+current_range if not autorange else ''}"
+        )
 
-    def measure_voltage(self):
+    def measure_voltage(self) -> float:
         """
         measure_voltage()
 
@@ -290,7 +303,7 @@ class HP_34401A(VisaResource):
         response = self._measure_with_current_range("VOLT:DC")
         return self.factor * float(response)
 
-    def measure_voltage_rms(self):
+    def measure_voltage_rms(self) -> float:
         """
         measure_voltage_rms()
 
@@ -307,7 +320,7 @@ class HP_34401A(VisaResource):
         response = self._measure_with_current_range("VOLT:AC")
         return self.factor * float(response)
 
-    def measure_current(self):
+    def measure_current(self) -> float:
         """
         measure_current()
 
@@ -324,7 +337,7 @@ class HP_34401A(VisaResource):
         response = self._measure_with_current_range("CURR:DC")
         return self.factor * float(response)
 
-    def measure_current_rms(self):
+    def measure_current_rms(self) -> float:
         """
         measure_current_rms()
 
@@ -341,7 +354,7 @@ class HP_34401A(VisaResource):
         response = self._measure_with_current_range("CURR:AC")
         return self.factor * float(response)
 
-    def measure_resistance(self):
+    def measure_resistance(self) -> float:
         """
         measure_resistance()
 
@@ -358,7 +371,7 @@ class HP_34401A(VisaResource):
         response = self._measure_with_current_range("RES")
         return float(response)
 
-    def measure_frequency(self):
+    def measure_frequency(self) -> float:
         """
         measure_frequency()
 

--- a/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
+++ b/pythonequipmentdrivers/_equipment/multimeter/hp_34401a.py
@@ -1,6 +1,8 @@
 from time import sleep
 from typing import Any, List, Union
 
+import pyvisa
+
 from pythonequipmentdrivers.core import VisaResource
 
 
@@ -102,7 +104,10 @@ class HP_34401A(VisaResource):
         self.trigger_mode = self.get_trigger_source()
 
     def __del__(self) -> None:
-        self.set_local()
+        try:
+            self.set_local()
+        except pyvisa.Error:
+            pass
         super().__del__()
 
     def set_mode(self, mode: str) -> None:

--- a/pythonequipmentdrivers/_equipment/oscilloscope/tektronix_dpo4xxx.py
+++ b/pythonequipmentdrivers/_equipment/oscilloscope/tektronix_dpo4xxx.py
@@ -294,7 +294,8 @@ class Tektronix_DPO4xxx(VisaResource):
         whether or not it is acquiring new data.
         """
 
-        self.write_resource("FPANEL:PRESS RUnstop")
+        self.write_resource("ACQUIRE:STOPAFTER RUNSTop")
+        self.write_resource("ACQUIRE:STATE ON")
 
     def trigger_force(self) -> None:
         """
@@ -312,7 +313,8 @@ class Tektronix_DPO4xxx(VisaResource):
         arms the oscilloscope to capture a single trigger event.
         """
 
-        self.write_resource("FPANEL:PRESS SING")
+        self.write_resource("ACQUIRE:STOPAFTER SEQUENCE")
+        self.write_resource("ACQUIRE:STATE ON")
 
     def set_trigger_position(self, offset: float) -> None:
         """
@@ -530,7 +532,9 @@ class Tektronix_DPO4xxx(VisaResource):
             return data[0]
         return tuple(data)
 
-    def get_image(self, image_title: Union[str, Path], **kwargs) -> None:
+    def get_image(
+        self, image_title: Union[str, Path], timeout_seconds: float = 2.0
+    ) -> None:
         """
         get_image(image_title, **kwargs)
 
@@ -558,17 +562,21 @@ class Tektronix_DPO4xxx(VisaResource):
         else:
             raise ValueError("image_title must be a str or path-like object")
 
+        prev_timeout = self._resource.timeout
+
+        self._resource.timeout = timeout_seconds * 1000
+
         # initiate transfer
         self._resource.write("SAVE:IMAG:FILEF PNG")  # set filetype
         self._resource.write("HARDCOPY START")  # start converting to image
-        self._resource.write("*OPC?")  # done yet?
-        sleep(kwargs.get("buffering_delay", 0))
 
         raw_data = self._resource.read_raw()
 
         # save image
         with open(file_path, "wb") as file:
             file.write(raw_data)
+
+        self._resource.timeout = prev_timeout
 
     def set_record_length(self, length: int) -> None:
         """

--- a/pythonequipmentdrivers/_equipment/source/keithley_2231a.py
+++ b/pythonequipmentdrivers/_equipment/source/keithley_2231a.py
@@ -1,3 +1,5 @@
+import pyvisa
+
 from pythonequipmentdrivers.core import VisaResource
 
 
@@ -22,7 +24,10 @@ class Keithley_2231A(VisaResource):
         self.set_access_remote("remote")
 
     def __del__(self) -> None:
-        self.set_access_remote("local")
+        try:
+            self.set_access_remote("local")
+        except pyvisa.Error:
+            pass
         super().__del__()
 
     def set_access_remote(self, mode: str) -> None:

--- a/pythonequipmentdrivers/core.py
+++ b/pythonequipmentdrivers/core.py
@@ -122,14 +122,14 @@ class VisaResource:
         try:
             self._resource = rm.open_resource(self.address, **default_settings)
 
+            if clear:
+                self.clear()
+
             self.idn = self.query_resource("*IDN?")
         except pyvisa.Error as error:
             raise ResourceConnectionError(
                 f"Could not connect to resource at: {address}", error
             )
-
-        if clear:
-            self.clear()
 
         self.timeout = int(1000 * kwargs.get("timeout", 1.0))  # ms
 

--- a/pythonequipmentdrivers/errors.py
+++ b/pythonequipmentdrivers/errors.py
@@ -1,8 +1,11 @@
-class UnsupportedResourceError(Exception):
+import pyvisa.errors
+
+
+class UnsupportedResourceError(pyvisa.errors.Error):
     def __init__(self, message="Device is not supported", *args):
         super().__init__(message, *args)
 
 
-class ResourceConnectionError(Exception):
+class ResourceConnectionError(pyvisa.errors.Error):
     def __init__(self, message="Could not connect to device", *args):
         super().__init__(message, *args)

--- a/pythonequipmentdrivers/resource_collections.py
+++ b/pythonequipmentdrivers/resource_collections.py
@@ -296,6 +296,10 @@ def connect_resources(config: Union[str, Path, dict], **kwargs) -> ResourceColle
 
             # create instance of Resource called 'name', any remaining items in
             # meta_info will be passed as kwargs
+            if "kwargs" in meta_info:
+                # old format with specific kwargs key
+                # flatten it out
+                meta_info.update(meta_info.pop("kwargs", {}))
             resource = Resource(**meta_info)
             setattr(resources, name, resource)
 

--- a/pythonequipmentdrivers/utility/data_management.py
+++ b/pythonequipmentdrivers/utility/data_management.py
@@ -4,6 +4,7 @@ from itertools import zip_longest
 from pathlib import Path
 from time import asctime, strftime
 from typing import Any, Dict, Iterable, List, Optional
+import csv
 
 __all__ = ("log_to_csv", "dump_data", "dump_array_data", "create_test_log", "Logger")
 
@@ -101,7 +102,9 @@ def dump_data(file_path: Path, data: Iterable[Iterable[Any]]) -> None:
         file_path (str, or path-like object): path of the log file to use, does
             not need to include the file extension or previously exist.
         data (Iterable[Iterable[Any]]): an iterable of iterables of data to be
-            stored. Each element should be able to be cast to string.
+            stored. Each element should be able to be cast to string. If the
+            inner iterable is a dict then the keys will be used as the column
+            names.
 
     Returns:
         NoneType
@@ -109,14 +112,20 @@ def dump_data(file_path: Path, data: Iterable[Iterable[Any]]) -> None:
 
     file_path = Path(file_path)
 
+    dict_based_data = isinstance(data[0], dict)
+
     # add/correct file extension
     file_path_ext = file_path.parent / f"{file_path.stem}.csv"
     file_path_ext.touch()  # create file
 
-    with open(file_path_ext, "w") as f:
-
-        for item in data:
-            print(*item, sep=",", file=f)
+    with open(file_path_ext, "w", newline="" if dict_based_data else None) as f:
+        if dict_based_data:
+            writer = csv.DictWriter(f, fieldnames=data[0].keys())
+            writer.writeheader()
+            writer.writerows(data)
+        else:
+            for item in data:
+                print(*item, sep=",", file=f)
 
 
 def dump_array_data(

--- a/pythonequipmentdrivers/utility/data_management.py
+++ b/pythonequipmentdrivers/utility/data_management.py
@@ -1,10 +1,10 @@
+import csv
 import json
 from dataclasses import dataclass, field
 from itertools import zip_longest
 from pathlib import Path
 from time import asctime, strftime
 from typing import Any, Dict, Iterable, List, Optional
-import csv
 
 __all__ = ("log_to_csv", "dump_data", "dump_array_data", "create_test_log", "Logger")
 


### PR DESCRIPTION
Currently addresses the following:

#20 
* add try except to problematic __del__ methods that may raise exceptions when the visa resource has already been closed

#21 and #22
* Added the complement of trigger configuration methods and used them to refactor the generic set_trigger method to reduce duplicated code
* With #22 in regards to adding set_trigger_level and set_trigger_slope, these are not functions that the HP34401A or Fluke 8845A support so I think they would best be added in a separate Keysight 34461A class if it supports them

#24 
* Fixed the issue with the basic measure_xxxx methods where they reset the range back to the default by adding a read back of the current range

Other updates included:
* Custom exceptions defined in `errors.py` changed to inherit from pyvisa.Error such that errors can be handled more generically bf85144
* In `data_management.py` `dump_data` updated to accept data in the form `list[dict]` in addition to `list[list]`. In the former case the dict keys will be used for the csv column names b311d06
* In `core.VisaResource.__init__` removed `self.clear` into the try clause such that the resource can be cleared prior to trying to read the idn 0e50853
* Add back kwargs json key support for `connect_resources()` for reverse compatibility 9cd296c
* Several minor change to `tektronix_dpo4xxx.py` 387e4c1
    * Change `trigger_single()` and `trigger_force()` to use the non front panel command version so they can be used with *OPC?
    * Updated `get_image()` command sequence so it does not throw an exception
   