### PR TITLE
Updated pyproject.toml to properly install subpackages (subdirectories)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pythonequipmentdrivers"
-version = "2.5.0"
+version = "2.5.1"
 authors = [
   { name="Anna Giasson", email="AnnaGraceGiasson@GMail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,6 @@ dependencies = [
 [project.urls]
 "Homepage" = "https://github.com/AnnaGiasson/PythonEquipmentDrivers"
 
-[tool.setuptools]
-packages = ["pythonequipmentdrivers"]
+[tool.setuptools.packages]
+find = {}
 


### PR DESCRIPTION
Fixed an error in pyproject.toml where subpackages (what setuptools refers to subdirectories as) were not being installed. It is now configured to find all packages which is the default behavior.