### PR TITLE
Implement automatic Enum conversion for device initialization. Add BK 9140 triple output source. Fix type hints to be compatible with python 3.8.

### DIFF
--- a/manifest.in
+++ b/manifest.in
@@ -1,0 +1,2 @@
+include pythonequipmentdrivers/*
+recursive-include pythonequipmentdrivers *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A library of software drivers to interface with various pieces of test instrumentation"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",

--- a/pythonequipmentdrivers/sink/Chroma_63600.py
+++ b/pythonequipmentdrivers/sink/Chroma_63600.py
@@ -29,6 +29,9 @@ class Chroma_63600(VisaResource):
         TIM = "TIM"
         SWD = "SWD"
 
+        def __str__(self):
+            return self.value
+
     class Errors(Enum):
         OTP = 0
         OVP = 1
@@ -452,7 +455,7 @@ class Chroma_63600(VisaResource):
             raise ValueError(f"Invalid range: {range_setting}")
 
         self.set_channel(channel)
-        self.write_resource(f"MODE {mode.value}{range_setting}")
+        self.write_resource(f"MODE {str(mode)}{range_setting}")
 
     def get_mode(self, channel: int) -> Tuple[ValidModes, str]:
         """

--- a/pythonequipmentdrivers/sink/Chroma_63600.py
+++ b/pythonequipmentdrivers/sink/Chroma_63600.py
@@ -29,9 +29,6 @@ class Chroma_63600(VisaResource):
         TIM = "TIM"
         SWD = "SWD"
 
-        def __str__(self):
-            return self.value
-
     class Errors(Enum):
         OTP = 0
         OVP = 1
@@ -318,7 +315,8 @@ class Chroma_63600(VisaResource):
         else:
             self.write_resource(f"CURR:DYN:T{level} {on_time}")
 
-    def get_dynamic_current_time(self, level: int) -> Union[float, Tuple[float]]:
+    def get_dynamic_current_time(self,
+                                 level: int) -> Union[float, Tuple[float]]:
         """
         get_dynamic_current_time(level)
 
@@ -455,7 +453,7 @@ class Chroma_63600(VisaResource):
             raise ValueError(f"Invalid range: {range_setting}")
 
         self.set_channel(channel)
-        self.write_resource(f"MODE {str(mode)}{range_setting}")
+        self.write_resource(f"MODE {mode.value}{range_setting}")
 
     def get_mode(self, channel: int) -> Tuple[ValidModes, str]:
         """

--- a/pythonequipmentdrivers/source/BKPrecision_9140.py
+++ b/pythonequipmentdrivers/source/BKPrecision_9140.py
@@ -1,0 +1,18 @@
+from .Keithley_2231A import Keithley_2231A
+
+
+# acts as an alias of Keithley_2231A
+class BKPrecision_9140(Keithley_2231A):
+    """
+    BKPrecision_9140(address)
+
+    address : str, address of the connected power supply
+
+    object for accessing basic functionallity of the B&K Precision DC supply
+    """
+
+    pass
+
+
+if __name__ == '__main__':
+    pass

--- a/pythonequipmentdrivers/source/BKPrecision_9140.py
+++ b/pythonequipmentdrivers/source/BKPrecision_9140.py
@@ -8,11 +8,224 @@ class BKPrecision_9140(Keithley_2231A):
 
     address : str, address of the connected power supply
 
-    object for accessing basic functionallity of the B&K Precision DC supply
+    object for accessing basic functionallity of the B&K Precision 9140 DC supply
     """
 
-    pass
+    def set_access_remote(self, mode: str) -> None:
+        """
+        set_access_remote(mode)
 
+        mode: str, interface method either 'remote' or 'RWLock' or 'local'
+        note that 'RWLock' will lock the front panel keys.
 
-if __name__ == '__main__':
-    pass
+        set access to the device inferface to 'remote' or 'RWLock' or 'local'
+        """
+
+        if mode.lower() == "remote":
+            self.write_resource("SYSTem:REMote")
+        elif mode.lower() == "rwlock":
+            self.write_resource("SYSTem:RWLock")
+        elif mode.lower() == "local":
+            self.write_resource("SYSTem:LOCal")
+        else:
+            raise ValueError(
+                'Unknown option for arg "mode", should be "remote" or "local"'
+            )
+
+    def set_channel(self, channel: int) -> None:
+        """
+        set_channel(channel)
+
+        channel: int, index of the channel to control.
+                 valid options are 0-2 coresponding to 1-3
+
+        Selects the specified Channel to use for software control
+        """
+
+        self.write_resource(f"INST:SEL {channel}")
+
+    def _update_channel(self, override_channel):
+        """Handles updating the device channel setting"""
+
+        if override_channel is not None:
+            self.set_channel(override_channel - 1)
+        elif self.channel is not None:
+            self.set_channel(self.channel - 1)
+        else:
+            raise TypeError(
+                "Channel number must be provided if it is not provided during"
+                + "initialization"
+            )
+        return
+
+    def get_channel(self) -> int:
+        """
+        get_channel()
+
+        Get current selected Channel
+
+        returns: int
+        """
+
+        response = self.query_resource("INST:SEL?")
+        return int(response) + 1
+
+    def set_state(self, state: bool, channel: int = None) -> None:
+        """
+        set_state(state, channel)
+
+        Enables/disables the output of the supply
+
+        Args:
+            state (bool): Supply state (True == enabled, False == disabled)
+            channel (int): Index of the channel to control. valid options
+                are 1-3
+        """
+
+        self._update_channel(channel)
+        self.write_resource(f"OUTP:STAT {1 if state else 0}")
+
+    def get_state(self, channel: int = None) -> bool:
+        """
+        get_state(channel)
+
+        Retrives the current state of the output of the supply.
+
+        Args:
+            channel (int): index of the channel to control. Valid options
+                are 1-3
+
+        Returns:
+            bool: Supply state (True == enabled, False == disabled)
+        """
+
+        self._update_channel(channel)
+        response = self.query_resource("OUTP:STAT?")
+        if response not in ("ON", "1"):
+            return False
+        return True
+
+    def all_get_state(self) -> bool:
+        """
+        all_get_state(channel)
+
+        Retrives the current state of the output of the supply.
+
+        Args:
+            None
+
+        Returns:
+            bool: Supply state (True == enabled, False == disabled)
+        """
+
+        response = self.query_resource("OUTP:ALL?")
+        if response not in ("ON", "1"):
+            return False
+        return True
+
+    def all_on(self) -> None:
+        """
+        all_on()
+
+        Enables the relay for ALL the power supply's outputs equivalent to
+        set_state(True).
+
+        Args:
+            None
+        """
+
+        self.write_resource(f"OUTP:ALL {1}")
+
+    def all_off(self) -> None:
+        """
+        all_off()
+
+        Disables the relay for ALL the power supply's outputs equivalent to
+        set_state(False).
+
+        Args:
+            None
+        """
+
+        self.write_resource(f"OUTP:ALL {0}")
+
+    def all_toggle(self) -> None:
+        """
+        all_toggle()
+
+        Reverses the current state of ALL the Supply's outputs
+
+        Args:
+            None
+        """
+
+        if self.all_get_state():
+            self.all_off()
+        else:
+            self.all_on()
+
+    def set_slewrate(self, slewrate: float, channel: int = None) -> None:
+        """
+        set_slewrate(current)
+
+        slewrate: float/int, slew rate setpoint in volts per second. Valid options are 0.001 to 3200.0 V/s.
+
+        channel: int=None, the index of the channel to set. Valid options are 1,2,3.
+
+        sets the slew rate setting for the power supply in V/s
+        """
+        if 0.001 < slewrate:
+            slewrate = 0.001
+        elif slewrate > 3200:
+            slewrate = 3200
+
+        self._update_channel(channel)
+        self.write_resource(f"VOLT:SLOP {slewrate}")
+
+    def get_slewrate(self, channel: int = None) -> float:
+        """
+        get_slewrate()
+
+        channel: int=None, the index of the channel to get. Valid options are 1,2,3.
+
+        gets the slew rate setting for the power supply in V/s
+
+        returns: float
+        """
+
+        self._update_channel(channel)
+        response = self.query_resource("VOLT:SLOP?")
+        return float(response)
+
+    def set_current_slewrate(self, slewrate: float, channel: int = None) -> None:
+        """
+        set_current_slewrate(current)
+
+        slewrate: float/int, slew rate setpoint in Amps per second. Valid options are 1 to 800.0 A/s.
+
+        channel: int=None, the index of the channel to set. Valid options are 1,2,3.
+
+        sets the current slew rate setting for the power supply in A/s
+        """
+        if 1 < slewrate:
+            slewrate = 1
+        elif slewrate > 800:
+            slewrate = 800
+
+        self._update_channel(channel)
+        self.write_resource(f"CURR:SLOP {slewrate}")
+
+    def get_current_slewrate(self, channel: int = None) -> float:
+        """
+        get_current_slewrate()
+
+        channel: int=None, the index of the channel to get. Valid options are 1,2,3.
+
+        gets the current slew rate setting for the power supply in A/s
+
+        returns: float
+        """
+
+        self._update_channel(channel)
+        response = self.query_resource("VOLT:SLOP?")
+        return float(response)

--- a/pythonequipmentdrivers/source/Chroma_62000P.py
+++ b/pythonequipmentdrivers/source/Chroma_62000P.py
@@ -12,6 +12,18 @@ class Chroma_62000P(VisaResource):
     object for accessing basic functionallity of the Chroma_62000P DC supply
     """
 
+    def set_access_remote(self, mode: bool = True) -> None:
+        """
+        set_access_remote(mode)
+
+        mode: str, interface method either 'remote' or 'local'
+
+        set access to the device inferface to 'remote' or 'local'
+        """
+
+        self.write_resource(
+            f"""'CONFigure:REMote {'ON' if mode else 'OFF'}'""")
+
     def set_state(self, state: bool) -> None:
         """
         set_state(state)

--- a/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
+++ b/pythonequipmentdrivers/temperaturecontroller/Koolance_EXC900.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from time import time
-from typing import Literal
+from typing import Literal, Dict
 
 from ..core import VisaResource
 
@@ -94,7 +94,7 @@ class Koolance_EXC900(VisaResource):
         self._last_read_data_time = None  # trigger a refresh on the next read
         self.write_resource_raw(data)
 
-    def read_settings(self) -> dict[str, float]:
+    def read_settings(self) -> Dict[str, float]:
         """
         read_settings()
 
@@ -102,11 +102,10 @@ class Koolance_EXC900(VisaResource):
         in a "key: value" format
 
         Returns:
-            dict[str, float]: dict of parameter names and their values
+            Dict[str, float]: dict of parameter names and their values
         """
-
         data = self._read_data()
-        out_dict: dict[str, float] = {}
+        out_dict: Dict[str, float] = {}
 
         for name, reg in self.DATA_REGISTER_MAP.items():
             value = data[reg.offset : reg.offset + reg.n_bytes]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
 env_list =
     format
+    py38
     py39
     py310
     py311
     py312
-    
+
 [testenv]
 base_python =
+    py38: python3.8-64
     py39: python3.9-64
     py310: python3.10-64
     py311: python3.11-64
@@ -22,11 +24,11 @@ commands =
 
 [testenv:format]
 description = install black in a virtual environment and invoke it on the current folder
-deps = 
+deps =
     black
     isort
 skip_install = true
-commands = 
+commands =
     black .
     isort .
 


### PR DESCRIPTION
This pull request introduces a generic mechanism for automatically converting string values to Enum values during device initialization. This change enhances the flexibility and maintainability of the device initialization process.

Key changes:
1. Added a new `convert_to_enum` function that attempts to convert string values to appropriate Enum values based on the Enums defined in the device instance.
2. Modified the `initiaize_device` function to use this conversion for all string arguments, regardless of the method being called or the specific Enum involved.

Benefits:
- Eliminates the need for method-specific conversion logic, making the code more maintainable.
- Allows JSON configuration files to continue using simple string values while ensuring proper Enum usage in method calls.
- Automatically handles new devices, methods, and Enums without requiring changes to the initialization logic.
- Improves code robustness by handling potential conversion errors gracefully.

This change maintains backwards compatibility with existing JSON configurations while providing a more flexible and future-proof solution for device initialization.

Python 3.8:
Some older systems in use are on windows 7 with no upgrade path. They are therefore stuck at python 3.8.
this library doesn't benefit from newer python 3.9+ syntax in any meaningful way, therefore reverted some type hints for backwards compatibility.  The discovery of the Enum issue resulted from this attempt.

Add Source:  Original intent was to add BK 9140 triple output source. This source inherits from but differs from the Keithley in that channel numbers start from zero and several strings for setting the output have different syntax. Added a couple of custom commands for slew rate since it can.
Also added a remote function to the chroma 62000.  Note that RWLock is being used in Keithley for remote control, this differs from just remote in that the panel is locked out until released to local. Safe to prevent device tamper, but can be an irritation in development where scripts pause.

Add Manifest.in to make sure that the build of the package always finds all of the subfolder modules when using pip install .

