### PR TITLE
Timeout bug fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pythonequipmentdrivers"
-version = "2.8.0"
+version = "2.8.1"
 authors = [
   { name="Anna Giasson", email="AnnaGraceGiasson@GMail.com" },
 ]

--- a/src/pythonequipmentdrivers/core.py
+++ b/src/pythonequipmentdrivers/core.py
@@ -131,7 +131,7 @@ class VisaResource:
                 f"Could not connect to resource at: {address}", error
             )
 
-        self.timeout = int(1000 * kwargs.get("timeout", 1.0))  # ms
+        self.timeout = kwargs.get("timeout", 1.0)  # s
 
     def clear_status(self, **kwargs) -> None:
         """

--- a/src/pythonequipmentdrivers/oscilloscope/_tektronix_dpo4xxx.py
+++ b/src/pythonequipmentdrivers/oscilloscope/_tektronix_dpo4xxx.py
@@ -857,6 +857,7 @@ class Tektronix_DPO4xxx(VisaResource):
         if setup_index not in range(1, 10 + 1):
             ValueError(f"{setup_index=} is not valid")
         self.write_resource(f"*SAV {setup_index}")
+        self.query_resource("*OPC?")
 
     def recall_setup(self, setup_index: int, timeout: float = 5) -> None:
         """


### PR DESCRIPTION
I fixed a bug where timeout was still being converted to ms in `VisaResource.__init__` this results in the timeout being set 1000x when using the default value.

Also added a missing *OPC? query in `Tektronix_DPO4xxx.store_config`